### PR TITLE
Fix dask 2021.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.3.0" %}
+{% set version = "2021.3.1" %}
 
 package:
   name: dask-core
@@ -7,7 +7,7 @@ package:
 source:
   fn: dask-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/d/dask/dask-{{ version }}.tar.gz
-  sha256: 566054b493d63c15732f2a640382b21e861571d61639f59341bc7695a9be138e
+  sha256: 1fa7e1809e7c50c5505297b03e6ee161e0695df73b4c4051b5b1c8fd670bf5d7
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,11 +16,11 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.7
     - pip
 
   run:
-    - python >=3.6
+    - python >=3.7
     - cloudpickle >=1.1.1
     - fsspec >=0.6.0
     - partd >=0.3.10

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,11 @@ requirements:
 
   run:
     - python >=3.6
+    - cloudpickle >=1.1.1
+    - fsspec >=0.6.0
+    - partd >=0.3.10
     - pyyaml
+    - toolz >=0.8.2
 
 test:
   imports:


### PR DESCRIPTION
It would be good to fix the existing packages. Dask 2021.3.1 dropped support for python 3.6.