### PR TITLE
Update `Dask-Core` to version `2021.11.2`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - partd >=0.3.10
     - pyyaml
     - toolz >=0.8.2
+    - locket
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.10.0" %}
+{% set version = "2021.11.2" %}
 
 package:
   name: dask-core
@@ -7,7 +7,7 @@ package:
 source:
   fn: dask-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/d/dask/dask-{{ version }}.tar.gz
-  sha256: a98b2e44acaad369bb21f79fc92f756532acfe62c3aeba3982006b7339d0d2e3
+  sha256: e12bfe272928d62fa99623d98d0e0b0c045b33a47509ef31a22175aa5fd10917
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
 #      dask-core --->distributed --->dask
 
 about:
-  home: http://github.com/dask/dask/
+  home: https://github.com/dask/dask/
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt


### PR DESCRIPTION

  `dask-core` version `2021.11.2`
1. - [x] check the upstream
    https://github.com/dask/dask/tree/2021.11.2

2. - [x] check the pinnings
    https://github.com/dask/dask/blob/2021.11.2/versioneer.py

    https://github.com/dask/dask/blob/2021.11.2/setup.py

    the earliest supported version of `python` is `3.7`
    https://github.com/dask/dask/blob/2021.11.2/setup.py#L79

    https://github.com/dask/dask/blob/2021.11.2/setup.cfg

    https://github.com/dask/dask/blob/2021.11.2/conftest.py

3. - [x] check the changelogs
    https://github.com/dask/dask/blob/2021.11.2/docs/source/changelog.rst

    there were some bug fixes mentioned in the changelog.

    some warnings were removed

4. - [x] additional research
    https://github.com/conda-forge/dask-core-feedstock/issues

    There were no open issues in `conda-forge` at the time of the review

5. - [x] verify dev_url
    https://github.com/dask/dask

6. - [x] verify doc_url
    https://dask.org/

7. - [x] license is spdx compliant
    https://spdx.org/licenses/BSD-3-Clause.html

8. - [x] license family
    https://spdx.org/licenses/BSD-3-Clause.html

9. - [x] verify the build number
    The build number is set to zero

10. - [x] verify setuptools
    setuptools is in the recipe

11. - [x] verify wheel
    wheel is in the recipe

12. - [x] pip in the test section
    Pip is in the test section

13. - [x] veriy the test section
    Verified the test section

Results:
-


Based on the research findings and the results we can conclude
that it is safe to update `dask-core` to version `2021.11.2`
