### PR TITLE
dask-core 2022.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,23 +16,29 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - setuptools
     - wheel
-
   run:
-    - python >=3.7
+    - python >=3.8
     - cloudpickle >=1.1.1
     - fsspec >=0.6.0
     - packaging >=20.0
     - partd >=0.3.10
-    - pyyaml
+    - pyyaml >=5.3.1
     - toolz >=0.8.2
 
 test:
   imports:
     - dask
+    - dask.array
+    - dask.bag
+    - dask.bytes
+    - dask.dataframe
+    - dask.dataframe.io
+    - dask.dataframe.tseries
+    - dask.diagnostics
   requires:
     - pip
   commands:
@@ -42,7 +48,7 @@ test:
 #      dask-core --->distributed --->dask
 
 about:
-  home: http://github.com/dask/dask/
+  home: https://github.com/dask/dask/
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ test:
   imports:
     - dask
   requires:
+    - locket
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,13 +32,6 @@ requirements:
 test:
   imports:
     - dask
-    - dask.array
-    - dask.bag
-    - dask.bytes
-    - dask.dataframe
-    - dask.dataframe.io
-    - dask.dataframe.tseries
-    - dask.diagnostics
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,6 @@ test:
   imports:
     - dask
   requires:
-    - locket
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.10.0" %}
+{% set version = "2022.2.1" %}
 
 package:
   name: dask-core
@@ -7,7 +7,7 @@ package:
 source:
   fn: dask-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/d/dask/dask-{{ version }}.tar.gz
-  sha256: a98b2e44acaad369bb21f79fc92f756532acfe62c3aeba3982006b7339d0d2e3
+  sha256: b699da18d147da84c6c0be26d724dc1ec384960bf1f23c8db4f90740c9ac0a89
 
 build:
   number: 0


### PR DESCRIPTION
Update dask-core to 2022.2.1

Version change: bump from 2021.10.0 to 2022.2.1
Changelog: https://docs.dask.org/en/latest/changelog.html
The License :https://github.com/dask/dask/blob/main/LICENSE.txt
Upstream Issues: https://github.com/dask/dask/issues
Requirements: https://github.com/dask/dask/blob/2022.02.1/setup.py

Actions:
1. Fix python in host
2. Update host dependencies: python >=3.8, pyyaml >=5.3.1
3. Update test/imports
4. Fix home url with HTTPS

Note: The build and dependency order for dask-distributed packages are as follows:
 `dask-core --->distributed --->dask`

