### PR TITLE
dask-core-2023.5.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels: 
-  jrice_org: jrice_org

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-#channels: 
-#  avalon-staging: dask_test
+channels: 
+  jrice1317: jrice_org

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels: 
-  jrice1317: jrice_org
+  jrice_org: jrice_org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,9 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: true  # [py<39]
 
+# Please note the repo used is the same as `dask`
+# Only the minimum reqs needed to build `dask` go here
+# Optional dependencies should exist in `dask` recipe
 requirements:
   host:
     - python
@@ -28,7 +31,7 @@ requirements:
     - python
     - click >=8.0
     - cloudpickle >=1.5.0
-    - fsspec >=0.9.0
+    - fsspec >=2021.09.0
     - packaging >=20.0
     - partd >=1.2.0
     - pyyaml >=5.3.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask-core" %}
-{% set version = "2023.4.1" %}
+{% set version = "2023.5.1" %}
 
 package:
   name: {{ name }}
@@ -7,14 +7,14 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/dask/dask-{{ version }}.tar.gz
-  sha256: 9dc72ebb509f58f3fe518c12dd5a488c67123fdd66ccb0b968b34fd11e512153
+  sha256: d1b988526012ac2896ace302347e23c003504f8baa69d106b75bd442f089495a
   entry_points:
     - dask = dask.__main__:main
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: true  # [py<38]
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -26,13 +26,13 @@ requirements:
     - tomli 2.0.1
   run:
     - python
-    - click >=7.0
-    - cloudpickle >=1.1.1
-    - fsspec >=0.6.0
+    - click >=8.0
+    - cloudpickle >=1.5.0
+    - fsspec >=0.9.0
     - packaging >=20.0
     - partd >=1.2.0
     - pyyaml >=5.3.1
-    - toolz >=0.8.2
+    - toolz >=0.10.0
     - importlib-metadata >=4.13.0
 
 test:
@@ -48,7 +48,7 @@ test:
 #      dask-core --->distributed --->dask
 
 about:
-  home: https://github.com/dask/dask/
+  home: https://www.dask.org/
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt


### PR DESCRIPTION
# Overview
## Links
- [Jira](https://anaconda.atlassian.net/browse/PKG-1948)
- [Upstream repository](https://github.com/dask/dask/tree/2023.5.1)
_**Please note:** `dask-core` uses the same repo as `dask`. The difference between the two is that `dask-core` is all the [minimum requirements](https://github.com/dask/dask/blob/2023.5.1/pyproject.toml#L29) needed for `dask` to run, while `dask` will contain `dask-core` and some (or all) of its [optional dependencies](https://github.com/dask/dask/blob/2023.5.1/pyproject.toml#L48) (granted no issues arise)_
- **Related Packages:** Needed for [distributed](https://anaconda.atlassian.net/browse/PKG-2147) and [dask](https://anaconda.atlassian.net/browse/PKG-2148)

--------------------
## Description

- Target channel: `defaults` for Anaconda Distribution 2023.06
### Dependency chain
`dask-core` -> `distributed` -> `dask`

--------------------
### Information checked from upstream: 

- [x] All dependency pinnings match with upstream.
- [x] All URLs are correct.
- [ ] abs.yaml is not present at time of review.

--------------------
### Recipe changes:
- Updated `version`, `sha256`, and `home_url`
- Removed `py38` support (according to upstream)
- Added note about relation to `dask`
- Updated following dependencies:
     - `click`
     - `cloudpickle`
     - `fsspec`
     - `toolz`

--------------------
### Tests conducted/Other misc notes:
- Ran conda-build locally and it built successfully
- Ran conda lint locally and an error about `packaging` being in the run section was noted but ignored due to upstream requirements
- Upload to private channel to test compatibility with related packages was successful
