### PR TITLE
2023.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask-core" %}
-{% set version = "2023.5.1" %}
+{% set version = "2023.6.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/dask/dask-{{ version }}.tar.gz
-  sha256: d1b988526012ac2896ace302347e23c003504f8baa69d106b75bd442f089495a
+  sha256: 980741966ef4d14c62dfb146f315f57d5eaaa6bedc52866f99687bc6054c2d4b
   entry_points:
     - dask = dask.__main__:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,3 +71,5 @@ extra:
     - sinhrks
     - tomaugspurger
     - jrbourbeau
+  skip-lint:
+    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,8 +44,7 @@ test:
   requires:
     - pip
   commands:
-    - pip check || true   # [not win]
-    - pip check || 1      # [win]
+    - pip check
 
 #Note: The build and dependency order for dask-distributed packages are as follows.
 #      dask-core --->distributed --->dask

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,5 +71,5 @@ extra:
     - sinhrks
     - tomaugspurger
     - jrbourbeau
-  skip-lint:
+  skip-lints:
     - python_build_tool_in_run


### PR DESCRIPTION
[Upstream](https://github.com/dask/dask)
[Changelog](https://docs.dask.org/en/stable/changelog.html)

### Actions
- Updated version to `2023.6.0`
- Reinstated `pip check` since it seems to work again
- Added a linter skip for `python_build_tool_in_run`