### PR TITLE
dask-core 2025.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask-core" %}
-{% set version = "2024.12.1" %}
+{% set version = "2025.2.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/dask/dask-{{ version }}.tar.gz
-  sha256: bac809af21c2dd7eb06827bccbfc612504f3ee6435580e548af912828f823195
+  sha256: 89c87125d04d28141eaccc4794164ce9098163fd22d8ad943db48f8d4c815460
   entry_points:
     - dask = dask.__main__:main
 


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7388](https://anaconda.atlassian.net/browse/PKG-7388)
- [Upstream repository](https://github.com/dask/dask/tree/2025.2.0)
- [Upstream changelog/diff](https://github.com/dask/dask/releases)

### Explanation of changes:

- Update version and sha256
