### PR TITLE
dask-core 2026.1.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask-core" %}
-{% set version = "2025.12.0" %}
+{% set version = "2026.1.2" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name.split('-')[0] }}/{{ name.split('-')[0] }}-{{ version }}.tar.gz
-  sha256: 8d478f2aabd025e2453cf733ad64559de90cf328c20209e4574e9543707c3e1b
+  sha256: 1136683de2750d98ea792670f7434e6c1cfce90cab2cc2f2495a9e60fd25a4fc
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ test:
     - pytest
   commands:
     - pip check
-    - pytest -v dask/tests -k "not (test_register_command_ep)"
+    - pytest -v dask/tests -k "not (test_register_command_ep or test_cpu_count_cgroups_v2)"
 
 # Note: The build and dependency order for dask-distributed packages are as follows.
 # dask-core -> @dask-expr@ -> distributed -> dask

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - numpy >=1.24
     - pandas >=2.0
     - pyarrow >=16.0
-    - distributed >=2026.1.2,<2026.1.3
+    - distributed =={{ version }}.*
     - bokeh >=3.1.0
     - jinja2 >=2.10.3
     - lz4 >=4.3.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,12 +38,12 @@ requirements:
     - importlib-metadata >=4.13.0  # [py<312]
   run_constrained:
     - numpy >=1.24
-    - pyarrow >=14.0.1
-    - lz4 >=4.3.2
     - pandas >=2.0
+    - pyarrow >=16.0
+    - distributed >=2026.1.2,<2026.1.3
     - bokeh >=3.1.0
     - jinja2 >=2.10.3
-    - distributed >=2025.12.0,<2025.12.1
+    - lz4 >=4.3.2
 
 # Tests must be added in the dask recipe:
 # https://github.com/AnacondaRecipes/dask-feedstock/blob/master/recipe/meta.yaml


### PR DESCRIPTION
dask-core 2026.1.2 

**Destination channel:** Defaults

### Links

- [PKG-11996]
- dev_url:        https://github.com/dask/dask
- conda_forge:    https://github.com/conda-forge/dask-core-feedstock
- pypi:           https://pypi.org/project/dask/2026.1.2
- pypi inspector: https://inspector.pypi.io/project/dask/2026.1.2

### Explanation of changes:

- new version number


[PKG-11996]: https://anaconda.atlassian.net/browse/PKG-11996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ