### PR TITLE
dask-core 2026.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask-core" %}
-{% set version = "2026.6.0" %}
+{% set version = "2026.7.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name.split('-')[0] }}/{{ name.split('-')[0] }}-{{ version }}.tar.gz
-  sha256: ae3436bd31ebce2be75edf952bd1fc687a1f11ec03fe8b1bec2903d222344a45
+  sha256: b039970642ce97a063070bae2763dada8aae27e3cbd8ff6d894072f920a1e252
 
 build:
   number: 0


### PR DESCRIPTION
## Links
- Jira: https://anaconda.atlassian.net/browse/PKG-16229
- Dev/project URL: https://github.com/dask/dask
- conda-forge recipe: https://github.com/conda-forge/dask-core-feedstock
- PyPI: https://pypi.org/project/dask/2026.7.0
- PyPI Inspector: https://inspector.pypi.io/project/dask/2026.7.0

## Changes
- Bump dask-core from 2026.6.0 to 2026.7.0
- Update sha256 for new source tarball

## Notes
- Routine monthly version bump, no breaking changes, no CVEs identified.
- Dependencies cross-checked against pyproject.toml and conda-forge dask-core-feedstock — no changes needed.